### PR TITLE
fix: align HEVC payload types between WebRTC and RTSP and add sp_wnq device category check

### DIFF
--- a/cmd/cameras/cameras.go
+++ b/cmd/cameras/cameras.go
@@ -250,7 +250,7 @@ func discoverCamerasForUser(user *storage.UserSession) ([]storage.CameraInfo, er
 			for _, room := range roomList.Result {
 				for _, device := range room.DeviceList {
 					// Check if device is a camera (sp = smart camera, dghsxj = another camera type)
-					if (device.Category == "sp" || device.Category == "dghsxj") && !containsDevice(devices, device.DeviceId) {
+					if (device.Category == "sp" || device.Category == "dghsxj" || device.Category == "sp_wnq") && !containsDevice(devices, device.DeviceId) {
 						devices = append(devices, device)
 					}
 				}

--- a/pkg/rtsp/forwarder.go
+++ b/pkg/rtsp/forwarder.go
@@ -77,7 +77,7 @@ func NewRTPForwarder() *RTPForwarder {
 	}
 }
 
-func (rf *RTPForwarder) AddUDPClient(sessionID string, videoRTPPort, audioRTPPort int) error {
+func (rf *RTPForwarder) AddUDPClient(sessionID string, clientIP string, videoRTPPort, audioRTPPort int) error {
 	rf.mutex.Lock()
 	defer rf.mutex.Unlock()
 
@@ -90,14 +90,14 @@ func (rf *RTPForwarder) AddUDPClient(sessionID string, videoRTPPort, audioRTPPor
 
 		// Create new connections if needed
 		if videoRTPPort > 0 && client.videoConn == nil {
-			videoAddr, _ := net.ResolveUDPAddr("udp", fmt.Sprintf("localhost:%d", videoRTPPort))
+			videoAddr, _ := net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%d", clientIP, videoRTPPort))
 			videoConn, _ := net.DialUDP("udp", nil, videoAddr)
 			client.videoAddr = videoAddr
 			client.videoConn = videoConn
 		}
 
 		if audioRTPPort > 0 && client.audioConn == nil {
-			audioAddr, _ := net.ResolveUDPAddr("udp", fmt.Sprintf("localhost:%d", audioRTPPort))
+			audioAddr, _ := net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%d", clientIP, audioRTPPort))
 			audioConn, _ := net.DialUDP("udp", nil, audioAddr)
 			client.audioAddr = audioAddr
 			client.audioConn = audioConn
@@ -116,7 +116,7 @@ func (rf *RTPForwarder) AddUDPClient(sessionID string, videoRTPPort, audioRTPPor
 
 	// Create video connection if port provided
 	if videoRTPPort > 0 {
-		videoAddr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("localhost:%d", videoRTPPort))
+		videoAddr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%d", clientIP, videoRTPPort))
 		if err != nil {
 			return fmt.Errorf("failed to resolve video UDP address: %v", err)
 		}
@@ -132,7 +132,7 @@ func (rf *RTPForwarder) AddUDPClient(sessionID string, videoRTPPort, audioRTPPor
 
 	// Create audio connection if port provided
 	if audioRTPPort > 0 {
-		audioAddr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("localhost:%d", audioRTPPort))
+		audioAddr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%d", clientIP, audioRTPPort))
 		if err != nil {
 			if client.videoConn != nil {
 				client.videoConn.Close()
@@ -154,8 +154,8 @@ func (rf *RTPForwarder) AddUDPClient(sessionID string, videoRTPPort, audioRTPPor
 
 	rf.clients[sessionID] = client
 
-	core.Logger.Trace().Msgf("Added UDP RTP client %s (video port:%d, audio port:%d)",
-		sessionID, videoRTPPort, audioRTPPort)
+	core.Logger.Trace().Msgf("Added UDP RTP client %s (IP: %s, video port:%d, audio port:%d)",
+		sessionID, clientIP, videoRTPPort, audioRTPPort)
 	return nil
 }
 

--- a/pkg/rtsp/protocol.go
+++ b/pkg/rtsp/protocol.go
@@ -549,9 +549,18 @@ func (s *RTSPServer) generateSDP(camera *storage.CameraInfo, baseURL string) str
 		if videoInfo != nil {
 			if isHEVC {
 				// H.265/HEVC
-				videoSdp += "m=video 0 RTP/AVP 96\r\n"
-				videoSdp += "a=rtpmap:96 H265/90000\r\n"
-				videoSdp += "a=fmtp:96 profile-id=1\r\n"
+				videoSdp += "m=video 0 RTP/AVP 100\r\n"
+				videoSdp += "a=rtpmap:100 H265/90000\r\n"
+				// Add width and height
+				videoSdp += fmt.Sprintf("a=imageattr:100 send [x=%d,y=%d] recv [x=%d,y=%d]\r\n",
+					videoInfo.Width, videoInfo.Height, videoInfo.Width, videoInfo.Height)
+				// Add more detailed fmtp line with profile and level
+				videoSdp += "a=fmtp:100 profile-id=1;level-asymmetry-allowed=1;packetization-mode=1;tier-flag=0;level-id=120\r\n"
+				// Add sprop-vps, sprop-sps, sprop-pps if available
+				if videoInfo.ProfileId != "" {
+					videoSdp += fmt.Sprintf("a=fmtp:100 sprop-vps=%s;sprop-sps=%s;sprop-pps=%s\r\n",
+						videoInfo.ProfileId, videoInfo.ProfileId, videoInfo.ProfileId)
+				}
 			} else {
 				// H.264
 				videoSdp += "m=video 0 RTP/AVP 96\r\n"

--- a/pkg/rtsp/protocol.go
+++ b/pkg/rtsp/protocol.go
@@ -36,6 +36,29 @@ type RTSPResponse struct {
 	Body       string
 }
 
+type RTSPClient struct {
+	conn                 net.Conn
+	session              string
+	cameraPath           string
+	stream               *CameraStream
+	reader               *bufio.Reader
+	transportMode        TransportMode
+	clientIP            string  // Add client IP field
+	videoRTPPort         int
+	videoRTCPPort        int
+	audioRTPPort         int
+	audioRTCPPort        int
+	backAudioRTPPort     int // server-side port for back audio
+	backAudioRTCPPort    int // server-side port for back audio RTCP
+	videoRTPChannel      byte
+	videoRTCPChannel     byte
+	audioRTPChannel      byte
+	audioRTCPChannel     byte
+	backAudioRTPChannel  byte
+	backAudioRTCPChannel byte
+	setupCount           int
+}
+
 func sendRTSPResponse(conn net.Conn, statusCode int, status string, headers map[string]string, body string) error {
 	var response strings.Builder
 
@@ -445,7 +468,7 @@ func (s *RTSPServer) handleSetup(client *RTSPClient, request *RTSPRequest) {
 		// Add/update UDP client with current ports after video and audio setup
 		if isVideoTrack || isAudioTrack {
 			err := client.stream.webrtcBridge.rtpForwarder.AddUDPClient(client.session,
-				client.videoRTPPort, client.audioRTPPort)
+				client.clientIP, client.videoRTPPort, client.audioRTPPort)
 			if err != nil {
 				core.Logger.Error().Err(err).Msg("Error adding UDP RTP client")
 				sendRTSPResponse(client.conn, 500, "Internal Server Error", nil,

--- a/pkg/tuya/helpers.go
+++ b/pkg/tuya/helpers.go
@@ -1,5 +1,9 @@
 package tuya
 
+import (
+	"tuya-ipc-terminal/pkg/core"
+)
+
 func GetStreamType(skill *Skill, streamResolution string) int {
 	// Default streamType if nothing is found
 	defaultStreamType := 1
@@ -44,6 +48,7 @@ func GetStreamType(skill *Skill, streamResolution string) int {
 func IsHEVC(skill *Skill, streamType int) bool {
 	for _, video := range skill.Videos {
 		if video.StreamType == streamType {
+			core.Logger.Info().Msgf("Checking video stream - StreamType: %d, CodecType: %d", video.StreamType, video.CodecType)
 			return video.CodecType == 4
 		}
 	}

--- a/pkg/webrtc/api.go
+++ b/pkg/webrtc/api.go
@@ -213,6 +213,7 @@ func RegisterDefaultCodecs(m *webrtc.MediaEngine) error {
 			RTPCodecCapability: webrtc.RTPCodecCapability{
 				MimeType:     webrtc.MimeTypeH265,
 				ClockRate:    90000,
+				SDPFmtpLine:  "profile-id=1;level-asymmetry-allowed=1;packetization-mode=1",
 				RTCPFeedback: videoRTCPFeedback,
 			},
 			PayloadType: 100,


### PR DESCRIPTION
This fixes the issue I was having in #3 

However I'm unable to test if it breaks other Tuya camera configurations, since I only have the one Tuya camera.