### PR TITLE
Add support for specifying RTSP server listening address

### DIFF
--- a/cmd/rtsp/rtsp.go
+++ b/cmd/rtsp/rtsp.go
@@ -45,6 +45,7 @@ func newStartCmd() *cobra.Command {
 		RunE:  runStartServer,
 	}
 
+	cmd.Flags().StringP("address", "a", "127.0.0.1", "RTSP server listening address. Use \"[::]\" to start server on all available addresses.")
 	cmd.Flags().IntP("port", "p", 8554, "RTSP server port")
 	cmd.Flags().BoolP("daemon", "d", false, "Run as daemon (background)")
 
@@ -83,6 +84,7 @@ func newListEndpointsCmd() *cobra.Command {
 }
 
 func runStartServer(cmd *cobra.Command, args []string) error {
+	address, _ := cmd.Flags().GetString("address")
 	port, _ := cmd.Flags().GetInt("port")
 	daemon, _ := cmd.Flags().GetBool("daemon")
 
@@ -113,7 +115,7 @@ func runStartServer(cmd *cobra.Command, args []string) error {
 	}
 
 	// Create and start RTSP server
-	rtspServer = rtsp.NewRTSPServer(port, storageManager)
+	rtspServer = rtsp.NewRTSPServer(address, port, storageManager)
 
 	core.Logger.Info().Msgf("Starting RTSP server on port %d...", port)
 

--- a/pkg/rtsp/server.go
+++ b/pkg/rtsp/server.go
@@ -16,6 +16,7 @@ import (
 )
 
 type RTSPServer struct {
+	address        string
 	port           int
 	listener       net.Listener
 	storageManager *storage.StorageManager
@@ -77,10 +78,11 @@ type ServerConfig struct {
 	EnableAuthentication bool
 }
 
-func NewRTSPServer(port int, storageManager *storage.StorageManager) *RTSPServer {
+func NewRTSPServer(address string, port int, storageManager *storage.StorageManager) *RTSPServer {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	return &RTSPServer{
+		address:         address,
 		port:           port,
 		storageManager: storageManager,
 		clients:        make(map[string]*RTSPClient),
@@ -99,7 +101,7 @@ func (s *RTSPServer) Start() error {
 		return errors.New("server is already running")
 	}
 
-	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", s.port))
+	listener, err := net.Listen("tcp", fmt.Sprintf("%s:%d", s.address, s.port))
 	if err != nil {
 		return fmt.Errorf("failed to listen on port %d: %v", s.port, err)
 	}
@@ -401,7 +403,7 @@ func (s *RTSPServer) printAvailableEndpoints() error {
 		json.Unmarshal([]byte(camera.Skill), &skill)
 
 		supportClarity := skill != nil && (skill.WebRTC&(1<<5)) != 0
-		baseUrl := fmt.Sprintf("rtsp://localhost:%d%s", s.port, camera.RTSPPath)
+		baseUrl := fmt.Sprintf("rtsp://%s:%d%s", s.address, s.port, camera.RTSPPath)
 
 		if supportClarity {
 			core.Logger.Info().Msgf("  %s/hd (%s)", baseUrl, camera.DeviceName)


### PR DESCRIPTION
1. This PR adds a new address parameter for `rtsp start` command.
2. Opening a server on all addresses was the default behaviour. That is probably not what the user wants by default, since it exposes cameras to the whole network.
3. The new default is to only listen on 127.0.0.1. This matches what was printed by `printAvailableEndpoints()` when starting server (`rtsp://localhost:8554/`).